### PR TITLE
Expose tiddler tags when rendering stream-row

### DIFF
--- a/plugins/streams/templates/stream-row-template.tid
+++ b/plugins/streams/templates/stream-row-template.tid
@@ -16,6 +16,7 @@ title: $:/plugins/sq/streams/templates/stream-row-template
 	<div class="tc-droppable-placeholder"/>
 	<div class={{{ stream-row [<row-children-visibility-state>get[text]match[hide]then[stream-row-children-collapsed]] +[join[ ]]}}}
 		data-node-title=<<currentTiddler>>
+		data-node-tags={{{ [<currentTiddler>tags[]addsuffix[;]] +[join[ ]] }}}
 	>
 		<$draggable
 			tag="div"


### PR DESCRIPTION
For each stream-row, expose the tags associated with its corresponding tiddler in an attribute called "data-node-tags".

Multiple tags are separated with ";".

This makes it easier to style the nodes based on tags on the tiddlers.