### PR TITLE
fix: check EDITOR_MAPPING_PREFIX before appending content type

### DIFF
--- a/plugins/streams/widgets/streams-edit.js
+++ b/plugins/streams/widgets/streams-edit.js
@@ -25,7 +25,9 @@ exports.prototype.getEditorType = function() {
 		}
 		return editorType;
 	}
-	editorType = this.wiki.getTiddlerText(EDITOR_MAPPING_PREFIX + type);
+	if(typeof EDITOR_MAPPING_PREFIX !== 'undefined' && EDITOR_MAPPING_PREFIX) {
+		editorType = this.wiki.getTiddlerText(EDITOR_MAPPING_PREFIX + type);
+	}
 	if(!editorType) {
 		var typeInfo = $tw.config.contentTypeInfo[type];
 		if(typeInfo && typeInfo.encoding === "base64") {


### PR DESCRIPTION
If a custom Streams template is specified in settings, EDITOR_MAPPING_PREFIX can be undefined and throw a Javascript exception. Check if EDITOR_MAPPING_PREFIX is defined. If not, leave `editorType` unassigned and try best-guess based on encoding.