### PR TITLE
Use $:/tags/ControlPanel/SettingsTab standard

### DIFF
--- a/plugins/streams/Settings.tid
+++ b/plugins/streams/Settings.tid
@@ -1,5 +1,5 @@
 title: $:/plugins/sq/streams/Settings
-tags: $:/tags/ControlPanel
-caption: Streams settings
+tags: $:/tags/ControlPanel/SettingsTab
+caption: Streams
 
 <<tabs "$:/plugins/sq/streams/Settings/config $:/plugins/sq/streams/Settings/shortcuts" "$:/plugins/sq/streams/Settings/config" "$:/state/streams/settings/tabs">>


### PR DESCRIPTION
Seems at that time, tw didn't support `$:/tags/ControlPanel/SettingsTab`. But not as it does, we should put all setting under this. And keep caption short.